### PR TITLE
Fix build issue and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@ This library is deprecated an no longer maintained. It is kept only for the QJum
 
 To build it, you must have the "cake" build system installed. You can obtain cake from https://github.com/Zomojo/Cake
 
-To insall cake, follow the instructions in "INSTALL". 
+Use the cake-3.0.856-1 version of the "cake" build system (https://github.com/Zomojo/compiletools/releases/tag/cake-3.0.856-1). Other versions might work as well but are not tested.
 
-To build camio, run "build.sh" in the root directory. 
+To download and install cake version 3.0.856-1: *sudo may be required when copying files*
+  1. `wget https://github.com/Zomojo/compiletools/archive/cake-3.0.856-1.tar.gz`
+  2. `tar -xvzf cake-3.0.856-1.tar.gz`
+  3. `cd compiletools-cake-3.0.856-1`
+  4. Copy the appropriate configuration file based on your distribution. For Ubuntu 14.04: `cp etc.cake.ubuntu.14.04 /etc/cake.conf`
+  5. `cp cake /usr/bin/cake`
+
+*Similar instructions can be found in the "INSTALL" file in the "cake" project directory, but they are slightly changed here.*
+
+To build camio, run "build.sh" in the root directory.

--- a/istreams/camio_istream_exa.c
+++ b/istreams/camio_istream_exa.c
@@ -32,7 +32,7 @@
 #include "../camio_util.h"
 #include "../clocks/camio_time.h"
 
-#include "camio/dag/dagapi.h"
+#include "../dag/dagapi.h"
 
 
 #define EXANIC_PORTS 4 //HACK! Assumes ExaNIC x4
@@ -261,6 +261,3 @@ camio_istream_t* camio_istream_exa_new( const camio_descr_t* descr,  camio_istre
     }
     return camio_istream_exa_construct(priv, descr,  params);
 }
-
-
-


### PR DESCRIPTION
The PR fixes two small issues:
1. The "cake" project has changed a lot in the last year. I installed the CamIO tools with a specific version of "cake" and I think it will be useful to have the instructions, in case someone else needs them.
2. While building CamIO there was a compilation error due to the path a header file had. I fixed the path and the `build.sh` script worked.