### PR TITLE
Update to use DAG driver 5.7.2

### DIFF
--- a/dag/daginf.h
+++ b/dag/daginf.h
@@ -73,6 +73,7 @@
 #define DAG_ID_SIZE 20 /* for daginf.bus_id, from BUS_ID_SIZE = KOBJ_NAME_LEN */
 typedef struct daginf {
 	uint32_t		id;		/* DAG device number */
+	int 			up_to_date;  /* 1 if up to date, 0 if not */
 
 	uint32_t		phy_addr ;
 //	unsigned long		phy_addr;	/* PCI address of large buffer (ptr) */
@@ -83,6 +84,7 @@ typedef struct daginf {
 #if defined(__linux__) || defined(__FreeBSD__) || (defined (__SVR4) && defined (__sun))
 	char			bus_id[DAG_ID_SIZE];
 	uint8_t 		brd_rev;	/**Card revision ID which is stored in the PCI configuration space */
+	uint32_t 		phy_addr_h; /**Upper 32 bits of the physical address of the large buffer */
 #endif
 #if defined(_WIN32)
 	uint32_t		bus_num;	/* PCI bus number */
@@ -92,6 +94,26 @@ typedef struct daginf {
 	uint16_t 		brd_rev;	/**Card revision ID which is stored in the PCI configuration space */
 #endif
 } daginf_t;
+
+/**
+ * New ioctl structures for DAG driver 5.7.1
+*/
+typedef struct dag_card_inf {
+        uint32_t                id;                     /* DAG device number 0 to DAG_MAX_BOARDS*/
+        uint32_t                flags;                  /* Flags */
+        uint32_t                iom_size;               /* iom size */
+        uint16_t                device_code;            /* PCI device ID */
+        uint8_t                 brd_rev;                /* Card rev ID from PCI conf space */
+        char                    bus_id[DAG_ID_SIZE];    /* PCI bus ID string */
+        int8_t                  bus_node;               /* PCI bus NUMA node */
+        char                    reserved[28];           /* reserved for future needs */
+} dag_card_inf_t;
+
+typedef enum duck_sync_method
+{
+	DUCK_PPS  = 0,
+	DUCK_PTP  = 1
+} duck_sync_method_t;
 
 /* Bitfields for DAG_IOSETDUCK, Set_Duck_Field parameter */
 /* Processing order is impled numerically ascending */
@@ -118,6 +140,7 @@ typedef struct duckinf
 	uint32_t	Health, Sickness;
 	int32_t		Freq_Err, Phase_Err;
 	uint32_t	Set_Duck_Field;
+	duck_sync_method_t Sync_Method; 
 } duckinf_t;
 
 

--- a/dag/dagnew.h
+++ b/dag/dagnew.h
@@ -175,6 +175,16 @@ typedef struct dag_meminfo
     uint32_t nid_pages[DAG_MAX_NODES];
 } dag_meminfo_t;
 
+
+typedef struct dag_memreq
+{
+	uint64_t base; /* This is a DMA address, not physical.*/
+	uint64_t size;
+	uint32_t stream;
+	uint32_t node;
+	uint32_t flags;
+}dag_memreq_t;
+
 /*
  * Dag iocontrols
  */
@@ -196,16 +206,19 @@ typedef struct dag_meminfo
 #else
 
 #define DAG_IOC_MAGIC  'd'
+/* Old ioctl commands, not yet updated */
 #define DAGIOCRESET    _IOW(DAG_IOC_MAGIC,  0, uint32_t)
 #define DAGIOCMONITOR  _IOWR(DAG_IOC_MAGIC, 1, monparams_t)
-#define DAGIOCINFO     _IOR(DAG_IOC_MAGIC,  2, daginf_t)
-#define DAGIOCLOCK     _IOWR(DAG_IOC_MAGIC, 3, int)
-#define DAGIOCDUCK     _IOWR(DAG_IOC_MAGIC, 4, duckinf_t)
-#define DAGIOCPHYADDR  _IOR(DAG_IOC_MAGIC, 5, uint64_t)
 #define DAGIOCIRQTIME  _IOR(DAG_IOC_MAGIC, 6, duck_irq_time_t)
 #define DAGIOCDEVNID  _IOR(DAG_IOC_MAGIC, 7, uint32_t)
 #define DAGIOCMEMINFO  _IOR(DAG_IOC_MAGIC, 8, dag_meminfo_t)
 #define DAGIOCSETMEM  _IOWR(DAG_IOC_MAGIC, 9, user_mem_t)
+
+/* Updated ioctl commands */
+#define DAGIOCINFO     _IOR(DAG_IOC_MAGIC,  3, dag_card_inf_t)
+#define DAGIOCLOCK     _IOW(DAG_IOC_MAGIC, 5, int)
+#define DAGIOCDUCK     _IOWR(DAG_IOC_MAGIC, 1, duckinf_t)
+#define DAGIOCSTREAMGETINFO _IOWR(DAG_IOC_MAGIC, 9, dag_memreq_t)
 
 #endif /* Solaris */
 


### PR DESCRIPTION
A few lines of update to use newer dag ioctl commands. 

Since the new commands are not 1-to-1 corresponding to the old ones, I have only updated the ones related to capturing from a dag. I tested using `dag_capture` from `qjump-camio-tools` and it worked fine. 